### PR TITLE
feature/DDCI-474-SSO---Disable-non-authenticated-access-to-data-catalogue

### DIFF
--- a/ckanext/qdes/access/middleware.py
+++ b/ckanext/qdes/access/middleware.py
@@ -1,0 +1,60 @@
+import logging
+import ckan.lib.api_token as api_token
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import ckan.views as views
+import six
+
+log = logging.getLogger(__name__)
+
+
+class QdesAuthMiddleware(object):
+    def __init__(self, app, app_conf):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        # if logged in via browser cookies or API key, all pages accessible
+        if 'repoze.who.identity' not in environ and not self._get_user_for_apikey(environ):
+            # The only pages allowed access to for unauthenticated users is home, login and reset pages
+            # But still allow access to assets and API
+            # API authentication will be handled by API auth/actions but some have public access
+            if environ['PATH_INFO'] not in ['/', '/user/login', '/user/reset'] \
+                    and not environ['PATH_INFO'].startswith('/base') \
+                    and not environ['PATH_INFO'].startswith('/api') \
+                    and not environ['PATH_INFO'].startswith('/webassets') \
+                    and not environ['PATH_INFO'].startswith('/images') \
+                    and not environ['PATH_INFO'].startswith('/css') \
+                    and not environ['PATH_INFO'].startswith('/js') \
+                    and not environ['PATH_INFO'].startswith('/_debug'):
+                status = "401 Unauthorized"
+                headers = [('Location', '/user.login'),
+                           ('Content-Length', '0')]
+
+                start_response(status, headers)
+
+        return self.app(environ, start_response)
+
+    def _get_user_for_apikey(self, environ):
+        # Based off method _get_user_for_apikey from https://github.com/ckan/ckan/blob/afe077e78e929a38112980d24df7c5d057b363ec/ckan/views/__init__.py
+        # Updated to remove request and use paramater environ
+        apikey_header_name = toolkit.config.get(views.APIKEY_HEADER_NAME_KEY,
+                                                views.APIKEY_HEADER_NAME_DEFAULT)
+        apikey = environ.get(apikey_header_name, u'')
+        if not apikey:
+            # For misunderstanding old documentation (now fixed).
+            apikey = environ.get(u'HTTP_AUTHORIZATION', u'')
+        if not apikey:
+            apikey = environ.get(u'Authorization', u'')
+            # Forget HTTP Auth credentials (they have spaces).
+            if u' ' in apikey:
+                apikey = u''
+        if not apikey:
+            return None
+
+        apikey = six.ensure_text(apikey, errors=u"ignore")
+        query = model.Session.query(model.User)
+        user = query.filter_by(apikey=apikey).first()
+
+        if not user:
+            user = api_token.get_user_from_token(apikey)
+        return user

--- a/ckanext/qdes/access/plugin.py
+++ b/ckanext/qdes/access/plugin.py
@@ -1,11 +1,16 @@
+import logging
 import ckan.plugins as plugins
-from ckanext.qdes.access import blueprint
+
+from ckanext.qdes.access import blueprint, middleware
 from ckanext.qdes.access.logic.auth import update as auth_update
+
+log = logging.getLogger(__name__)
 
 
 class QdesAccessPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IAuthFunctions)
+    plugins.implements(plugins.IMiddleware, inherit=True)
 
     # IBlueprint
     def get_blueprint(self):
@@ -16,3 +21,7 @@ class QdesAccessPlugin(plugins.SingletonPlugin):
         return {
             'user_update': auth_update.user_update,
         }
+
+    # IMiddleware
+    def make_middleware(self, app, config):
+        return middleware.QdesAuthMiddleware(app, config)


### PR DESCRIPTION
Created 'QdesAuthMiddleware' to restrict access to only authenticated users excepts home, login, reset pages and asset's/api's