### PR TITLE
[DDCI-650]

### DIFF
--- a/ckanext/qdes/access/blueprint.py
+++ b/ckanext/qdes/access/blueprint.py
@@ -1,107 +1,11 @@
 import logging
 
-import ckan.lib.mailer as mailer
-import ckan.model as model
 import ckan.plugins.toolkit as toolkit
-from ckan.views.user import RequestResetView
+import ckan.views.user as ckan_view_user
 from flask import Blueprint
 
 log = logging.getLogger(__name__)
 qdes_access = Blueprint('qdes_access', __name__)
-h = toolkit.h
-get_action = toolkit.get_action
-NotFound = toolkit.ObjectNotFound
-g = toolkit.g
-request = toolkit.request
-_ = toolkit._
 
 
-def request_reset():
-    '''
-    This method is copied from the ckan user view class method RequestResetView.post
-    It is a exact copy so will need to be checked and updated if necessary on any CKAN upgrades
-    There are a few modifications to check if the user requesting a password reset is a sysadmin
-    Only sysadmins are sent a reset link email
-    '''
-    RequestResetView._prepare(RequestResetView())
-    id = request.form.get(u'user')
-    if id in (None, u''):
-        h.flash_error(_(u'Email is required'))
-        return h.redirect_to(u'/user/reset')
-    log.info(u'Password reset requested for user "{}"'.format(id))
-
-    context = {u'model': model, u'user': g.user, u'ignore_auth': True}
-    user_objs = []
-
-    # Usernames cannot contain '@' symbols
-    if u'@' in id:
-        # Search by email address
-        # (You can forget a user id, but you don't tend to forget your
-        # email)
-        user_list = get_action(u'user_list')(context, {
-            u'email': id
-        })
-        if user_list:
-            # send reset emails for *all* user accounts with this email
-            # (otherwise we'd have to silently fail - we can't tell the
-            # user, as that would reveal the existence of accounts with
-            # this email address)
-            for user_dict in user_list:
-                # This is ugly, but we need the user object for the mailer,
-                # and user_list does not return them
-                # Qdes modifications begin
-                user = get_action(u'user_show')(
-                    context, {u'id': user_dict[u'id']})
-                if user.get('sysadmin', False):
-                    user_objs.append(context[u'user_obj'])
-                else:
-                    log.info(
-                        u'User requested reset link for a non sysadmin user: {}'.format(id))
-                # Qdes modifications end
-
-    else:
-        # Search by user name
-        # (this is helpful as an option for a user who has multiple
-        # accounts with the same email address and they want to be
-        # specific)
-        try:
-            # Qdes modifications begin
-            user = get_action(u'user_show')(context, {u'id': id})
-            if user.get('sysadmin', False):
-                user_objs.append(context[u'user_obj'])
-            else:
-                log.info(
-                    u'User requested reset link for a non sysadmin user: {}'.format(id))
-            # Qdes modifications end
-        except NotFound:
-            pass
-
-    if not user_objs:
-        log.info(u'User requested reset link for unknown user: {}'
-                 .format(id))
-
-    for user_obj in user_objs:
-        log.info(u'Emailing reset link to user: {}'
-                 .format(user_obj.name))
-        try:
-            # FIXME: How about passing user.id instead? Mailer already
-            # uses model and it allow to simplify code above
-            mailer.send_reset_link(user_obj)
-        except mailer.MailerException as e:
-            # SMTP is not configured correctly or the server is
-            # temporarily unavailable
-            h.flash_error(_(u'Error sending the email. Try again later '
-                            'or contact an administrator for help'))
-            log.exception(e)
-            return h.redirect_to(u'home.index')
-
-    # always tell the user it succeeded, because otherwise we reveal
-    # which accounts exist or not
-    h.flash_success(
-        _(u'A reset link has been emailed to you '
-            '(unless the account specified does not exist)'))
-    return h.redirect_to(u'home.index')
-
-
-qdes_access.add_url_rule(
-    u'/user/reset', view_func=request_reset, methods=[u'POST'])
+qdes_access.add_url_rule(u'/service/login', view_func=ckan_view_user.login)

--- a/ckanext/qdes/access/logic/auth/get.py
+++ b/ckanext/qdes/access/logic/auth/get.py
@@ -5,3 +5,15 @@ import ckan.plugins.toolkit as toolkit
 def api_token_list(next_auth, context, data_dict):
     # sysadmins only
     return {'success': False}
+
+
+@toolkit.auth_sysadmins_check
+def user_reset(context, data_dict):
+    # No access
+    return {'success': False}
+
+
+@toolkit.auth_sysadmins_check
+def request_reset(context, data_dict):
+    # No access
+    return {'success': False}

--- a/ckanext/qdes/access/middleware.py
+++ b/ckanext/qdes/access/middleware.py
@@ -15,23 +15,28 @@ class QdesAuthMiddleware(object):
     def __call__(self, environ, start_response):
         # if logged in via browser cookies or API key, all pages accessible
         if 'repoze.who.identity' not in environ and not self._get_user_for_apikey(environ):
-            # The only pages unauthenticated users have access to are below
-            # login, password reset, saml2login, acs (SAML Assertion Consumer Service) and user unauthorised
-            # But still allow unauthenticated access to assets and API
+            # The only pages unauthorized users have access to are below
+            # service login, saml2login, acs (SAML Assertion Consumer Service), user unauthorised and logout pages
+            # But still allow unauthorized access to assets and API
             # API authentication will be handled by API auth/actions but some have public access
-            if (environ['PATH_INFO'] not in ['/user/login', '/user/saml2login', '/acs', '/user/unauthorised'] \
-                and not environ['PATH_INFO'].startswith('/user/reset')) \
-                and not environ['PATH_INFO'].startswith('/base') \
-                and not environ['PATH_INFO'].startswith('/api') \
-                and not environ['PATH_INFO'].startswith('/webassets') \
-                and not environ['PATH_INFO'].startswith('/images') \
-                and not environ['PATH_INFO'].startswith('/css') \
-                and not environ['PATH_INFO'].startswith('/js') \
-                and not environ['PATH_INFO'].startswith('/_debug') \
-                and not environ['PATH_INFO'].startswith('/uploads'):
-                status = "401 Unauthorized"
-                headers = [('Location', '/user.login'),
+            unauthorized_pages_allowed = toolkit.aslist(toolkit.config.get('ckanext.qdes_access.unauthorized_pages_allowed', ''))
+            if environ['PATH_INFO'] not in unauthorized_pages_allowed \
+                    and not environ['PATH_INFO'].startswith('/base') \
+                    and not environ['PATH_INFO'].startswith('/api') \
+                    and not environ['PATH_INFO'].startswith('/webassets') \
+                    and not environ['PATH_INFO'].startswith('/images') \
+                    and not environ['PATH_INFO'].startswith('/css') \
+                    and not environ['PATH_INFO'].startswith('/js') \
+                    and not environ['PATH_INFO'].startswith('/_debug') \
+                    and not environ['PATH_INFO'].startswith('/uploads'):
+
+                log.debug(f"Unauthorized page accessed: {environ['PATH_INFO']}")
+                # Status code needs to be 3xx (redirection) for Location header to be used
+                status = "302 Unauthorized"
+                location = toolkit.config.get('ckanext.qdes_access.unauthorized_redirect_location', '/user/saml2login')
+                headers = [('Location', location),
                            ('Content-Length', '0')]
+                log.debug(f"Redirecting to: {location}")
                 start_response(status, headers)
                 # Return now as we want to end the request
                 return []

--- a/ckanext/qdes/access/plugin.py
+++ b/ckanext/qdes/access/plugin.py
@@ -30,7 +30,9 @@ class QdesAccessPlugin(plugins.SingletonPlugin):
             'group_edit_permissions': auth_update.group_edit_permissions,
             'member_create': auth_create.member_create,
             'member_delete': auth_delete.member_delete,
-            'api_token_list': auth_get.api_token_list
+            'api_token_list': auth_get.api_token_list,
+            'user_reset': auth_get.user_reset,
+            'request_reset': auth_get.request_reset
         }
 
     # IMiddleware

--- a/ckanext/qdes/access/templates/header.html
+++ b/ckanext/qdes/access/templates/header.html
@@ -10,3 +10,21 @@
         </li>
     {% endif %}
 {% endblock %}
+
+{% block header_site_navigation %}
+    {% if c.userobj %}
+        {{ super() }}
+    {% endif %}
+{% endblock %}
+
+{% block header_site_search %}
+    {% if c.userobj %}
+        {{ super() }}
+    {% endif %}
+{% endblock %}
+
+{% block header_site_navigation_desktop %}
+    {% if c.userobj %}
+        {{ super() }}
+    {% endif %}
+{% endblock %}

--- a/ckanext/qdes/access/templates/user/login.html
+++ b/ckanext/qdes/access/templates/user/login.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+  {# This will make sure the user register and user forgotten your password sections are not displayed #}
+{% endblock %}


### PR DESCRIPTION
SSO - Handle non-authenticated, non-authorised and Salsa system admin users https://it-partners.atlassian.net/browse/DDCI-650
- Added new blueprint route '/service/login' the will display the default ckan login page
- Updated middleware to use CKAN config values for 'unauthorized_pages_allowed' and 'unauthorized_redirect_location'
- Updated middleware to use 302 redirect status code to use Location header
- Added auth overrides for 'user_reset' & 'request_reset' to have no access
- Updated header.html template to only display 'header_site_navigation' & 'header_site_search' & 'header_site_navigation_desktop' if user is authenticated
- Added login.html template override to not display user register and forgotten password sections