### PR TITLE
[SUPDESQ-59] Jobworker monitor ENV variabale (#53)

### DIFF
--- a/ckanext/qdes/jobs.py
+++ b/ckanext/qdes/jobs.py
@@ -147,11 +147,16 @@ def mark_as_reviewed(datasets):
     except Exception as e:
         log.error(str(e))
 
+
 def ckan_worker_job_monitor():
+    monitor_url = os.environ.get('MONITOR_QDES_JOBWORKER')
     try:
-        log.info(f'Sending notification to healthchecks for CKAN worker job monitor')
-        requests.get("https://hc-ping.com/60b47f7c-7f12-4936-a9be-e5b7193b2677", timeout=10)
-        log.info(f'Successfully sent notification to healthchecks for CKAN worker job monitor')
+        if monitor_url:
+            log.info(f'Sending notification for CKAN worker job monitor')
+            requests.get(monitor_url, timeout=10)
+            log.info(f'Successfully sent notification for CKAN worker job monitor')
+        else:
+            log.error(f'The env variable MONITOR_QDES_JOBWORKER is not set for CKAN worker job monitor')
     except requests.RequestException as e:
-        log.error(f'Failed to send ckan worker job monitor notification to healthchecks')
+        log.error(f'Failed to send ckan worker job monitor notification to {monitor_url}')
         log.error(str(e))


### PR DESCRIPTION
* [SUPDESQ-59] Use the ENV variable for jobworkier ping check

* Check if ENV variable exists

* [SUPDESQ-59] Remove healthchecks references

* Log if the MONITOR_QDES_JOBWORKER env is not set

* Refactoring code and formatting

Co-authored-by: Mark Calvert <markcalvert84@gmail.com>